### PR TITLE
Conditionally render content explicitly

### DIFF
--- a/packages/esm-patient-alerts-app/src/notifications-menu-button.component.tsx
+++ b/packages/esm-patient-alerts-app/src/notifications-menu-button.component.tsx
@@ -17,7 +17,7 @@ const NotificationsMenuButton: React.FC<NotificationsMenuButtonProps> = ({ isAct
 
   return (
     <>
-      {alerts?.length && (
+      {alerts?.length ? (
         <HeaderGlobalAction
           aria-label="Notifications"
           aria-labelledby="Notifications Icon"
@@ -32,7 +32,7 @@ const NotificationsMenuButton: React.FC<NotificationsMenuButtonProps> = ({ isAct
             <Notification20 />
           )}
         </HeaderGlobalAction>
-      )}
+      ) : null}
     </>
   );
 };

--- a/packages/esm-patient-alerts-app/src/patient-alerts.component.tsx
+++ b/packages/esm-patient-alerts-app/src/patient-alerts.component.tsx
@@ -120,7 +120,7 @@ export default function PatientAlertsComponent({ expanded }: PatientAlertsCompon
 
   return (
     <>
-      {expanded && (
+      {expanded ? (
         <div className={styles.notificationsPanel}>
           {viewState.status === 'loading' ? (
             <InlineLoading
@@ -155,7 +155,7 @@ export default function PatientAlertsComponent({ expanded }: PatientAlertsCompon
             </p>
           ) : null}
         </div>
-      )}
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION
Render content conditionally using ternaries instead of abusing the `&&` boolean operator. I know I could solve the problem by using `!!alerts.length &&` but I prefer the explicitness of the ternary operator. https://kentcdodds.com/blog/use-ternaries-rather-than-and-and-in-jsx

<img width="884" alt="Screenshot 2021-08-11 at 20 40 49" src="https://user-images.githubusercontent.com/8509731/129082758-728b111a-2b60-421e-964d-81c63dd6bb8d.png">
