### PR TITLE
Add Error state for HIV-Summary & start on hiv-clinical summary pdf

### DIFF
--- a/packages/esm-hiv-summary-app/src/hiv-summary.component.tsx
+++ b/packages/esm-hiv-summary-app/src/hiv-summary.component.tsx
@@ -7,6 +7,7 @@ import HivLatestSummary from './widgets/hiv-latest-summary/hiv-latest-summary.co
 import HivSummaryHistorical from './widgets/hiv-summary-historical/hiv-summary-historical.component';
 import { HivSummaryProvider } from './hooks/useHivSummary';
 import HIVMedicationChangeHistory from './widgets/hiv-medication-change-history/hiv-medication-change-history.component';
+import HIVClinicalSummary from './widgets/hiv-clinical-summary/hiv-clinical-summary.component';
 
 interface HivSummaryProps {
   patientUuid: string;
@@ -45,6 +46,7 @@ const HivSummary: React.FC<HivSummaryProps> = ({ patient, patientUuid }) => {
           <div>{selectedSwitchIndex === 0 && <HivLatestSummary patient={patient} />}</div>
           <div>{selectedSwitchIndex === 1 && <HivSummaryHistorical />}</div>
           <div>{selectedSwitchIndex === 2 && <HIVMedicationChangeHistory patientUuid={patientUuid} />}</div>
+          <div>{selectedSwitchIndex === 3 && <HIVClinicalSummary patientUuid={patientUuid} />}</div>
         </div>
       </div>
     </HivSummaryProvider>

--- a/packages/esm-hiv-summary-app/src/hooks/useHivSummary.tsx
+++ b/packages/esm-hiv-summary-app/src/hooks/useHivSummary.tsx
@@ -1,8 +1,9 @@
-import { createErrorHandler } from '@openmrs/esm-framework';
 import { StructuredListSkeleton } from 'carbon-components-react';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { fetchHivSummary } from '../hiv-summary.resource';
 import { HIVSummary } from '../types';
+import { ErrorState } from '../widgets/error/error-state.component';
 
 enum StateTypes {
   PENDING = 'pending',
@@ -29,7 +30,9 @@ export function useHivSummaryContext() {
 }
 
 export const HivSummaryProvider: React.FC<HivSummaryProviderProps> = ({ children, patient, patientUuid }) => {
+  const { t } = useTranslation();
   const [status, setStatus] = React.useState<ViewState>(StateTypes.PENDING);
+  const [error, setError] = React.useState<Error>(null);
   const [hivSummaryData, setHivSummaryData] = React.useState<Array<HIVSummary>>([]);
   React.useEffect(() => {
     const sub = fetchHivSummary(patientUuid).subscribe(
@@ -37,7 +40,10 @@ export const HivSummaryProvider: React.FC<HivSummaryProviderProps> = ({ children
         setHivSummaryData((prevState) => [...prevState, ...hivSummary]);
         setStatus(StateTypes.RESOLVED);
       },
-      (error) => createErrorHandler(),
+      (error) => {
+        setError(error);
+        setStatus(StateTypes.ERROR);
+      },
     );
     return () => sub.unsubscribe();
   }, [patientUuid]);
@@ -50,6 +56,7 @@ export const HivSummaryProvider: React.FC<HivSummaryProviderProps> = ({ children
     <HivSummaryContext.Provider value={memorizedHivSummary}>
       {status === StateTypes.PENDING && <StructuredListSkeleton />}
       {status === StateTypes.RESOLVED && children}
+      {status === StateTypes.ERROR && <ErrorState headerTitle={t('hivSummary', 'HIV Summary')} error={error} />}
     </HivSummaryContext.Provider>
   );
 };

--- a/packages/esm-hiv-summary-app/src/index.ts
+++ b/packages/esm-hiv-summary-app/src/index.ts
@@ -19,6 +19,7 @@ function setupOpenMRS() {
       {
         id: 'hiv-summary-widget',
         slot: 'patient-chart-summary-dashboard-slot',
+        order: 0,
         load: getAsyncLifecycle(() => import('./hiv-summary.component'), options),
         meta: {
           columnSpan: 4,

--- a/packages/esm-hiv-summary-app/src/widgets/error/error-state.component.tsx
+++ b/packages/esm-hiv-summary-app/src/widgets/error/error-state.component.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styles from './error-state.scss';
+import { Tile } from 'carbon-components-react';
+import { useTranslation } from 'react-i18next';
+
+export interface ErrorStateProps {
+  error: any;
+  headerTitle: string;
+}
+
+export const ErrorState: React.FC<ErrorStateProps> = ({ error, headerTitle }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Tile light className={styles.tile}>
+      <h1 className={styles.heading}>{headerTitle}</h1>
+      <p className={styles.errorMessage}>
+        {t('error', 'Error')} {`${error?.response?.status}: `}
+        {error?.response?.statusText}
+      </p>
+      <p className={styles.errorCopy}>
+        {t(
+          'errorCopy',
+          'Sorry, there was a problem displaying this information. You can try to reload this page, or contact the site administrator and quote the error code above.',
+        )}
+      </p>
+    </Tile>
+  );
+};

--- a/packages/esm-hiv-summary-app/src/widgets/error/error-state.scss
+++ b/packages/esm-hiv-summary-app/src/widgets/error/error-state.scss
@@ -1,0 +1,37 @@
+@import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vars";
+@import "~carbon-components/src/globals/scss/mixins";
+
+.errorMessage {
+  @include carbon--type-style("productive-heading-02");
+  color: $text-01;
+  margin-top: 2.25rem;
+  margin-bottom: $spacing-03;
+}
+
+.errorCopy {
+  margin-bottom: $spacing-03;
+  @include carbon--type-style("body-long-01");
+  color: $text-02;
+}
+
+.heading {
+  text-align: left;
+  text-transform: capitalize;
+  margin-bottom: $spacing-05;
+  @include carbon--type-style("productive-heading-03");
+  color: $text-02;
+}
+
+.heading:after {
+  content: "";
+  display: block;
+  width: 2rem;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid $brand-teal-01;
+}
+
+.tile {
+  text-align: center;
+  border: 1px solid $ui-03;
+}

--- a/packages/esm-hiv-summary-app/src/widgets/hiv-clinical-summary/hiv-clinical-summary.component.scss
+++ b/packages/esm-hiv-summary-app/src/widgets/hiv-clinical-summary/hiv-clinical-summary.component.scss
@@ -1,0 +1,1 @@
+@import '../../root.scss'

--- a/packages/esm-hiv-summary-app/src/widgets/hiv-clinical-summary/hiv-clinical-summary.component.test.tsx
+++ b/packages/esm-hiv-summary-app/src/widgets/hiv-clinical-summary/hiv-clinical-summary.component.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import HIVClinicalSummary from './hiv-clinical-summary.component';
+import { render, screen } from '@testing-library/react';
+const mockPatientUuid = 'some-patient-uuid';
+describe('HIVClinicalSummary', () => {
+  it('renders without dying', () => {
+    render(<HIVClinicalSummary patientUuid={mockPatientUuid} />);
+    expect(screen.getByText(/HIV Clinical Summary/i)).toBeInTheDocument();
+  });
+});

--- a/packages/esm-hiv-summary-app/src/widgets/hiv-clinical-summary/hiv-clinical-summary.component.tsx
+++ b/packages/esm-hiv-summary-app/src/widgets/hiv-clinical-summary/hiv-clinical-summary.component.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styles from './hiv-clinical-summary.component.scss';
+
+interface HIVClinicalSummaryProps {
+  patientUuid: string;
+}
+
+const HIVClinicalSummary: React.FC<HIVClinicalSummaryProps> = ({ patientUuid }) => {
+  return (
+    <div>
+      <h2>HIV Clinical Summary</h2>
+    </div>
+  );
+};
+
+export default HIVClinicalSummary;

--- a/packages/esm-hiv-summary-app/translations/en.json
+++ b/packages/esm-hiv-summary-app/translations/en.json
@@ -12,6 +12,8 @@
   "encounterDateChange": "Encounter Date change",
   "encounterType": "Encounter Type",
   "enrollmentDate": "Enrollment Date",
+  "error": "Error",
+  "errorCopy": "Sorry, there was a problem displaying this information. You can try to reload this page, or contact the site administrator and quote the error code above.",
   "historicalHIVSummary": "Historical HIV Summary",
   "hivClinicalSummary": "HIV Clinical Summary",
   "hivMedicationChangeHistory": "Medication Change History",


### PR DESCRIPTION
### What does this PR

1. Add error state when loading HIV-Summary fails
2. Start of HIV Clinical Summary PDF
3. Order HIV Summary to the top of patient-chart-dashboard-summary