### PR TITLE
Fix active notifications indicator icon

### DIFF
--- a/packages/esm-patient-alerts-app/src/notifications-menu-button.scss
+++ b/packages/esm-patient-alerts-app/src/notifications-menu-button.scss
@@ -1,6 +1,7 @@
 @import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vars";
 
-.unreadAlertsIndicator > circle {
+.unreadNotificationsIndicator > circle {
   color: red;
   stroke: white;
   stroke-width: 2px;
@@ -10,6 +11,6 @@
   background-color: transparent;
 
   &:hover {
-    background-color: $brand-02
+    background-color: $brand-02;
   }
 }


### PR DESCRIPTION
The active notifications indicator button with the red dot wasn't showing up because of a mismatched class name.