### PR TITLE
Fix notifications menu button styling

### DIFF
--- a/packages/esm-patient-alerts-app/src/notifications-menu-button.component.tsx
+++ b/packages/esm-patient-alerts-app/src/notifications-menu-button.component.tsx
@@ -17,6 +17,7 @@ const NotificationsMenuButton: React.FC<NotificationsMenuButtonProps> = ({ isAct
 
   return (
     <HeaderGlobalAction
+      className={styles.menuButton}
       aria-label="Notifications"
       aria-labelledby="Notifications Icon"
       name="Notifications"

--- a/packages/esm-patient-alerts-app/src/notifications-menu-button.scss
+++ b/packages/esm-patient-alerts-app/src/notifications-menu-button.scss
@@ -1,5 +1,15 @@
+@import "~@openmrs/esm-styleguide/src/vars";
+
 .unreadAlertsIndicator > circle {
   color: red;
   stroke: white;
   stroke-width: 2px;
+}
+
+.menuButton {
+  background-color: transparent;
+
+  &:hover {
+    background-color: $brand-02
+  }
 }

--- a/packages/esm-patient-alerts-app/src/patient-alerts.resource.ts
+++ b/packages/esm-patient-alerts-app/src/patient-alerts.resource.ts
@@ -29,7 +29,7 @@ export function useAlerts(patientUuid: string) {
   const referenceDate = dayjs().format('YYYY-MM-DD');
   const apiUrl = `/etl-latest/etl/patient/${patientUuid}/hiv-clinical-reminder/${referenceDate}`;
 
-  const { data, error } = useSWR<{ data: EtlRemindersResponse }, Error>(patientUuid ? apiUrl : null, openmrsFetch, {});
+  const { data, error } = useSWR<{ data: EtlRemindersResponse }, Error>(patientUuid ? apiUrl : null, openmrsFetch);
 
   return {
     data: data ? data.data.result.reminders : [],


### PR DESCRIPTION
This commit fixes the styling of the notifications menu button so that its look matches the rest of the icons in the navigation menu.

## Videos

https://user-images.githubusercontent.com/8509731/144896075-ac1098b6-6325-4990-b1da-8bf633bd91c9.mp4

