### PR TITLE
Remove order property of extension in favour of config provided ordering

### DIFF
--- a/packages/esm-hiv-summary-app/src/index.ts
+++ b/packages/esm-hiv-summary-app/src/index.ts
@@ -21,7 +21,6 @@ function setupOpenMRS() {
       {
         id: 'hiv-summary-widget',
         slot: 'patient-chart-summary-dashboard-slot',
-        order: 0,
         load: getAsyncLifecycle(() => import('./hiv-summary.component'), options),
         meta: {
           columnSpan: 4,
@@ -30,7 +29,6 @@ function setupOpenMRS() {
       {
         id: 'hiv-summary-overview-widget',
         slot: dashboardMeta.slot,
-        order: 0,
         load: getAsyncLifecycle(() => import('./widgets/hiv-summary-overview/hiv-summary-overview.component'), options),
         meta: {
           columnSpan: 4,
@@ -39,7 +37,6 @@ function setupOpenMRS() {
       {
         id: 'hiv-summary-nav-link',
         slot: 'patient-chart-dashboard-slot',
-        order: 1,
         load: getSyncLifecycle(createDashboardLink(dashboardMeta), options),
         meta: dashboardMeta,
         online: true,


### PR DESCRIPTION
### What does this PR do?

- Remove the `order` property of `hiv-summary-widgets` in favour of order being provided by config file, reasoning being it is confusing syncing default order of extensions and config provided order of extensions