### PR TITLE
Enhancements to the alerts feature

### DIFF
--- a/packages/esm-patient-alerts-app/src/notifications-menu-button.component.tsx
+++ b/packages/esm-patient-alerts-app/src/notifications-menu-button.component.tsx
@@ -13,7 +13,7 @@ interface NotificationsMenuButtonProps {
 }
 
 const NotificationsMenuButton: React.FC<NotificationsMenuButtonProps> = ({ isActivePanel, togglePanel }) => {
-  const { hasUnreadAlerts, hasViewedAlerts } = useStore(patientAlertsStore);
+  const { alerts } = useStore(patientAlertsStore);
 
   return (
     <HeaderGlobalAction
@@ -25,7 +25,7 @@ const NotificationsMenuButton: React.FC<NotificationsMenuButtonProps> = ({ isAct
       onClick={() => togglePanel('notificationsMenu')}>
       {isActivePanel('notificationsMenu') ? (
         <Close20 />
-      ) : hasUnreadAlerts && !hasViewedAlerts ? (
+      ) : alerts?.length ? (
         <NotificationNew20 className={styles.unreadNotificationsIndicator} title="Unread alerts" />
       ) : (
         <Notification20 />

--- a/packages/esm-patient-alerts-app/src/patient-alerts.scss
+++ b/packages/esm-patient-alerts-app/src/patient-alerts.scss
@@ -5,7 +5,7 @@
 }
 
 .emptyState {
-  margin: 2rem 1rem 0rem 1rem;
+  margin: 1rem 1rem 0rem;
   color: $ui-background;
 }
 

--- a/packages/esm-patient-alerts-app/src/store.ts
+++ b/packages/esm-patient-alerts-app/src/store.ts
@@ -1,17 +1,25 @@
 import { Store } from 'unistore';
 import { createGlobalStore } from '@openmrs/esm-framework';
+import { Reminder } from './patient-alerts.resource';
 
 export interface PatientAlertsStore {
+  alerts: Array<Reminder>;
   hasUnreadAlerts: boolean;
   hasViewedAlerts: boolean;
   patientId: string | null;
 }
 
 export const patientAlertsStore: Store<PatientAlertsStore> = createGlobalStore('patient-alerts', {
+  alerts: [],
   hasUnreadAlerts: false,
   hasViewedAlerts: false,
   patientId: null,
 });
+
+export const setAlerts = patientAlertsStore.action((state, value: Array<Reminder>) => ({
+  ...state,
+  alerts: value,
+}));
 
 export const setHasUnreadAlerts = patientAlertsStore.action((state, value: boolean) => ({
   ...state,


### PR DESCRIPTION
These include the following:

- Render alerts (when available) as toast notifications once a user loads a patient chart. These toasts automatically disappear from the screen after 10 seconds.
- The user can access alerts (when available) at any time by clicking the notification icon in the navigation bar.
- Alerts with a `type` property of value `danger` are now property colour-coded to the `error` colour token.
- Toasts in the notification panel are now properly colour coded as well.
- The notification icon button now renders the `NotificationNew20` icon button whenever alerts are present.

## Screenshots

<img width="1679" alt="Screenshot 2022-01-27 at 15 32 41" src="https://user-images.githubusercontent.com/8509731/151361888-2db5ea4d-8201-49a5-a7b5-7edaae651f8a.png">
<img width="1681" alt="Screenshot 2022-01-27 at 15 32 54" src="https://user-images.githubusercontent.com/8509731/151361899-f7eaba66-ec15-4a68-b419-9cfa6b5940f5.png">

