### PR TITLE
Remove `hasUnreadAlerts` state from the alerts store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 ![Node.js CI](https://github.com/ampath/ampath-esm-clinic-dashboard/workflows/Node.js%20CI/badge.svg)
-# Ampath Clinic dashboard
 
-This is a [lerna](https://lerna.js.org) project containing ampath clinic dashboard micro-frontend.
-This package includes the following
+# Ampath Clinic Dashboard
+
+This is a [lerna](https://lerna.js.org) project containing packages that make up the AMPATH Clinic Dashboard.
+
+## Available Packages
+
+The packages bundled in this repo include:
 
   - [@ampath/esm-hiv-clinic-dashboard-app](packages/esm-hiv-clinic-dashboard-app)
   - [@ampath/esm-hiv-summary-app](packages/esm-hiv-summary-app)
+  - [@ampath/esm-patient-alerts-app](packages/esm-patient-alerts-app) 
 
 ## Repository Development
 
@@ -16,7 +21,6 @@ This package includes the following
 - lerna  ```sh npm install lerna -g ```
 
 ### Getting started
-
 
 To install and setup the repository once cloned, just use the following command
 

--- a/packages/esm-patient-alerts-app/src/notifications-menu-button.test.tsx
+++ b/packages/esm-patient-alerts-app/src/notifications-menu-button.test.tsx
@@ -37,7 +37,6 @@ describe('NotificationsMenuButtonComponent', () => {
   test('renders an icon button in the navbar with an unread notifications indicator when unread notifications are present', () => {
     mockUseStore.mockImplementationOnce(() => ({
       alerts: mockAlerts,
-      hasUnreadAlerts: true,
       hasViewedAlerts: false,
     }));
 
@@ -50,7 +49,6 @@ describe('NotificationsMenuButtonComponent', () => {
   test('renders an icon button in the navbar without an unread notifications indicator when there are no notifications (or no unread notifications) to display', () => {
     mockUseStore.mockImplementationOnce(() => ({
       alerts: [],
-      hasUnreadAlerts: false,
       hasViewedAlerts: false,
     }));
 

--- a/packages/esm-patient-alerts-app/src/patient-alerts.component.tsx
+++ b/packages/esm-patient-alerts-app/src/patient-alerts.component.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { showToast, usePatient, useStore } from '@openmrs/esm-framework';
 import { SearchSkeleton, ToastNotification } from 'carbon-components-react';
 import { useAlerts } from './patient-alerts.resource';
-import { patientAlertsStore, setHasUnreadAlerts, setHasViewedAlerts, setAlerts } from './store';
+import { patientAlertsStore, setHasViewedAlerts, setAlerts } from './store';
 import styles from './patient-alerts.scss';
 
 interface PatientAlertsComponentProps {
@@ -18,7 +18,6 @@ export default function PatientAlertsComponent({ expanded }: PatientAlertsCompon
 
   React.useEffect(() => {
     if (!expanded && alerts.length && !hasViewedAlerts) {
-      setHasUnreadAlerts(true);
       setAlerts(alerts);
       alerts.map((alert) => {
         showToast({

--- a/packages/esm-patient-alerts-app/src/store.ts
+++ b/packages/esm-patient-alerts-app/src/store.ts
@@ -4,14 +4,12 @@ import { Reminder } from './patient-alerts.resource';
 
 export interface PatientAlertsStore {
   alerts: Array<Reminder>;
-  hasUnreadAlerts: boolean;
   hasViewedAlerts: boolean;
   patientId: string | null;
 }
 
 export const patientAlertsStore: Store<PatientAlertsStore> = createGlobalStore('patient-alerts', {
   alerts: [],
-  hasUnreadAlerts: false,
   hasViewedAlerts: false,
   patientId: null,
 });
@@ -19,11 +17,6 @@ export const patientAlertsStore: Store<PatientAlertsStore> = createGlobalStore('
 export const setAlerts = patientAlertsStore.action((state, value: Array<Reminder>) => ({
   ...state,
   alerts: value,
-}));
-
-export const setHasUnreadAlerts = patientAlertsStore.action((state, value: boolean) => ({
-  ...state,
-  hasUnreadAlerts: value,
 }));
 
 export const setHasViewedAlerts = patientAlertsStore.action((state, value: boolean) => ({


### PR DESCRIPTION
The current implementation of the alerts feature works just as well without this bit of state. This  PR also updates the README page with information about the alerts microfrontend.