### PR TITLE
(enhancement) add branding support for `hiv-summary-widget` and `patient-alerts-widget`

### DIFF
--- a/packages/esm-hiv-summary-app/src/hiv-summary.component.scss
+++ b/packages/esm-hiv-summary-app/src/hiv-summary.component.scss
@@ -24,7 +24,8 @@
   display: block;
   width: 2rem;
   padding-top: 0.188rem;
-  border-bottom: 0.375rem solid $brand-teal-01;
+  border-bottom: 0.375rem solid;
+  @include brand-03(border-bottom-color);
 }
 
 .contentSwitcherContainer {

--- a/packages/esm-patient-alerts-app/src/notifications-menu-button.component.tsx
+++ b/packages/esm-patient-alerts-app/src/notifications-menu-button.component.tsx
@@ -14,16 +14,16 @@ interface NotificationsMenuButtonProps {
 
 const NotificationsMenuButton: React.FC<NotificationsMenuButtonProps> = ({ isActivePanel, togglePanel }) => {
   const { alerts } = useStore(patientAlertsStore);
-
+  const isActive = isActivePanel('notificationsMenu');
   return (
     <HeaderGlobalAction
-      className={styles.menuButton}
+      className={isActive ? styles.activeMenuButton : styles.menuButton}
       aria-label="Notifications"
       aria-labelledby="Notifications Icon"
       name="Notifications"
       isActive={isActivePanel('notificationsMenu')}
       onClick={() => togglePanel('notificationsMenu')}>
-      {isActivePanel('notificationsMenu') ? (
+      {isActive ? (
         <Close20 />
       ) : alerts?.length ? (
         <NotificationNew20 className={styles.unreadNotificationsIndicator} title="Unread alerts" />

--- a/packages/esm-patient-alerts-app/src/notifications-menu-button.scss
+++ b/packages/esm-patient-alerts-app/src/notifications-menu-button.scss
@@ -2,8 +2,8 @@
 @import "~carbon-components/src/globals/scss/vars";
 
 .unreadNotificationsIndicator > circle {
-  color: red;
-  stroke: white;
+  color: $danger;
+  stroke: $ui-02;
   stroke-width: 2px;
 }
 
@@ -11,6 +11,10 @@
   background-color: transparent;
 
   &:hover {
-    background-color: $brand-02;
+    @include brand-02(background-color)
   }
+}
+
+.activeMenuButton {
+  @include brand-02(background-color)
 }


### PR DESCRIPTION
### What does this PR do?

- Add branding for the HIV summary widget header
- Add branding support for patient-alerts notification button


### Screenshoot

![hiv-summary-branding](https://user-images.githubusercontent.com/28008754/151650414-b0e04193-8e4b-4ed0-a7ff-aa4c5c81ec80.gif)

