### PR TITLE
(feat) Modifications to the reminders feature

### DIFF
--- a/packages/esm-patient-alerts-app/src/notifications-menu-button.component.tsx
+++ b/packages/esm-patient-alerts-app/src/notifications-menu-button.component.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import Close20 from '@carbon/icons-react/lib/close/20';
 import Notification20 from '@carbon/icons-react/es/notification/20';
-import NotificationNew20 from '@carbon/icons-react/es/notification--new/20';
 import { HeaderGlobalAction } from 'carbon-components-react';
-import { useStore } from '@openmrs/esm-framework';
-import { patientAlertsStore } from './store';
 import styles from './notifications-menu-button.scss';
 
 interface NotificationsMenuButtonProps {
@@ -13,7 +10,6 @@ interface NotificationsMenuButtonProps {
 }
 
 const NotificationsMenuButton: React.FC<NotificationsMenuButtonProps> = ({ isActivePanel, togglePanel }) => {
-  const { alerts } = useStore(patientAlertsStore);
   const isActive = isActivePanel('notificationsMenu');
   return (
     <HeaderGlobalAction
@@ -23,13 +19,7 @@ const NotificationsMenuButton: React.FC<NotificationsMenuButtonProps> = ({ isAct
       name="Notifications"
       isActive={isActivePanel('notificationsMenu')}
       onClick={() => togglePanel('notificationsMenu')}>
-      {isActive ? (
-        <Close20 />
-      ) : alerts?.length ? (
-        <NotificationNew20 className={styles.unreadNotificationsIndicator} title="Unread alerts" />
-      ) : (
-        <Notification20 />
-      )}
+      {isActive ? <Close20 /> : <Notification20 />}
     </HeaderGlobalAction>
   );
 };

--- a/packages/esm-patient-alerts-app/src/notifications-menu-button.test.tsx
+++ b/packages/esm-patient-alerts-app/src/notifications-menu-button.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useStore } from '@openmrs/esm-framework';
 import { render, screen } from '@testing-library/react';
 import NotificationsMenuButton from './notifications-menu-button.component';
 
@@ -8,54 +7,11 @@ const testProps = {
   togglePanel: jest.fn(),
 };
 
-const mockUseStore = useStore as jest.Mock;
-
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
-
-  return {
-    ...originalModule,
-    useStore: jest.fn(),
-  };
-});
-
 describe('NotificationsMenuButtonComponent', () => {
-  const mockAlerts = [
-    {
-      message: 'No contact tracing has been done for this index, please fill the  contact tracing form',
-      title: 'Contact Tracing Reminder',
-      type: 'warning',
-      display: {
-        banner: true,
-        toast: true,
-      },
-      action: true,
-      addContacts: true,
-    },
-  ];
-
-  test('renders an icon button in the navbar with an unread notifications indicator when unread notifications are present', () => {
-    mockUseStore.mockImplementationOnce(() => ({
-      alerts: mockAlerts,
-      hasViewedAlerts: false,
-    }));
-
+  test('renders an icon button in the navbar', () => {
     renderNotificationsMenuButtonComponent();
 
     expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument();
-    expect(screen.getByTitle(/Unread alerts/i)).toBeInTheDocument();
-  });
-
-  test('renders an icon button in the navbar without an unread notifications indicator when there are no notifications (or no unread notifications) to display', () => {
-    mockUseStore.mockImplementationOnce(() => ({
-      alerts: [],
-      hasViewedAlerts: false,
-    }));
-
-    renderNotificationsMenuButtonComponent();
-
-    expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument();
-    expect(screen.queryByTitle(/Unread alerts/i)).not.toBeInTheDocument();
   });
 });
 

--- a/packages/esm-patient-alerts-app/src/patient-alerts.resource.ts
+++ b/packages/esm-patient-alerts-app/src/patient-alerts.resource.ts
@@ -1,17 +1,18 @@
 import dayjs from 'dayjs';
-import useSWR from 'swr';
 import { NotificationKind } from 'carbon-components-react';
 import { openmrsFetch } from '@openmrs/esm-framework';
+import useSWRImmutable from 'swr/immutable';
+import useSWR from 'swr';
 
 export interface Reminder {
-  action: boolean;
   display: {
     toast: boolean;
-    banner: string;
+    banner: boolean;
   };
   message: string;
   title: string;
   type: NotificationKind | 'danger';
+  action?: boolean;
   addContacts?: boolean;
   updateContacts?: boolean;
   auto_register?: boolean;
@@ -34,6 +35,6 @@ export function useAlerts(patientUuid: string) {
   return {
     alerts: data ? data?.data?.result?.reminders : [],
     isError: error,
-    isLoading: patientUuid && !data && !error,
+    isLoadingAlerts: patientUuid && !data && !error,
   };
 }

--- a/packages/esm-patient-alerts-app/src/patient-alerts.test.tsx
+++ b/packages/esm-patient-alerts-app/src/patient-alerts.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, useStore } from '@openmrs/esm-framework';
 import { mockPatient } from '../../../__mocks__/mock-patient';
 import { swrRender, waitForLoadingToFinish } from '../../../tools/test-helpers';
 import PatientAlertsComponent from './patient-alerts.component';
@@ -10,6 +10,7 @@ const testProps = {
 };
 
 const mockOpenmrsFetch = openmrsFetch as jest.Mock;
+const mockUseStore = useStore as jest.Mock;
 
 const testReminders = [
   {
@@ -36,6 +37,9 @@ jest.mock('@openmrs/esm-framework', () => {
       error: null,
       isLoading: false,
       patient: mockPatient,
+      patientUuid: mockPatient.id,
+    })),
+    useStore: jest.fn(() => ({
       patientUuid: mockPatient.id,
     })),
   };

--- a/packages/esm-patient-alerts-app/src/store.ts
+++ b/packages/esm-patient-alerts-app/src/store.ts
@@ -4,14 +4,12 @@ import { Reminder } from './patient-alerts.resource';
 
 export interface PatientAlertsStore {
   alerts: Array<Reminder>;
-  hasViewedAlerts: boolean;
-  patientId: string | null;
+  patientUuid: string | null;
 }
 
 export const patientAlertsStore: Store<PatientAlertsStore> = createGlobalStore('patient-alerts', {
   alerts: [],
-  hasViewedAlerts: false,
-  patientId: null,
+  patientUuid: null,
 });
 
 export const setAlerts = patientAlertsStore.action((state, value: Array<Reminder>) => ({
@@ -19,7 +17,7 @@ export const setAlerts = patientAlertsStore.action((state, value: Array<Reminder
   alerts: value,
 }));
 
-export const setHasViewedAlerts = patientAlertsStore.action((state, value: boolean) => ({
+export const setPatientUuid = patientAlertsStore.action((state, value: string) => ({
   ...state,
-  hasViewedAlerts: value,
+  patientUuid: value,
 }));


### PR DESCRIPTION
This commit makes the following modifications to the reminders feature:

- Reminders from the previous patient no longer persist when a new patient chart gets loaded.
- Increase the timeout for reminder toasts to 10 seconds. The current 5-second timeout duration is too short for the user to parse the content of the reminders in any meaningful way. I talked to Ciaran about this and he reckons that ideally, these toasts should require user intervention to dismiss. That would require changes to the toast implementation in `esm-core`. We'll explore this further and incorporate those changes once done.
- Remove the `NotificationNew20` unread notifications indicator icon button. Ciaran and I agree that it's not exactly clear when the unread notifications indicator should appear in the navbar. It's not clear cut how one should determine that a user has `seen` a patient's reminders, especially now that reminders get rendered as toasts automatically upon loading a patient chart. We resolved to remove this feature for now until we get more clarity.